### PR TITLE
fix crash rn 79: mixin Animated.Value & primitive seems to cause crash

### DIFF
--- a/src/modal.tsx
+++ b/src/modal.tsx
@@ -706,6 +706,9 @@ export class ReactNativeModal extends React.Component<ModalProps, State> {
       </TouchableWithoutFeedback>
     );
   };
+
+  private stableAnimatedValueZero = new Animated.Value(0);
+
   render() {
     /* eslint-disable @typescript-eslint/no-unused-vars */
     const {
@@ -733,7 +736,7 @@ export class ReactNativeModal extends React.Component<ModalProps, State> {
 
     const { testID, ...containerProps } = otherProps;
     const computedStyle = [
-      { margin: this.getDeviceWidth() * 0.05, transform: [{ translateY: 0 }] },
+      { margin: this.getDeviceWidth() * 0.05, transform: [{ translateY: this.stableAnimatedValueZero }] },
       styles.content,
       style,
     ];


### PR DESCRIPTION
`react-native-modal` crash with rn 79 because somehow we're not allowed to mix `transform` with primitive value and Animated.Value at the same time...


I'll open an issue on react-native, I'll link the issue when it will be ready 